### PR TITLE
Add option to control page blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ see more demo in [unit test](test/index.test.js)
 - `script`: `string` is an option param. inject script source to evaluate when page on load
 - `renderTimeout`: `number` in ms, `render()` will throw error if html string can't be resolved after `renderTimeout`, default is 5000ms.
 - `deviceMetricsOverride`: `object` overrides the values of device screen dimensions for responsive websites, detail use see [here](https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride)
+- `clearPool`: `boolean` if `true` after render chrome instance will navigate to `about:blank` to free resources. default is true. setting to `false` may increase page load speed when rendering the same website.
 
 all request from chrome-render will take with a HTTP header `x-chrome-render:${version}`
  

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,6 +45,10 @@ export default class ChromeRender {
      * `object` Overrides the values of device screen dimensions, same as https://chromedevtools.github.io/devtools-protocol/tot/Emulation/#method-setDeviceMetricsOverride
      */
     deviceMetricsOverride?: object,
+    /**
+     * `boolean` if `true` after render chrome instance will navigate to `about:blank` to free resources. default is true. setting to `false` may increase page load speed when rendering the same website.
+     */
+    clearPool?: boolean,
   }): Promise<string>;
 
   /**

--- a/index.js
+++ b/index.js
@@ -157,10 +157,10 @@ new Promise((fulfill) => {
         referrer: headers['referrer']
       });
     }).then((html) => {
-      this.chromePoll.release(client.tabId);
+      this.chromePoll.release(client.tabId, params.clearPool);
       return Promise.resolve(html);
     }).catch((err) => {
-      this.chromePoll.release(client.tabId);
+      this.chromePoll.release(client.tabId, params.clearPool);
       return Promise.reject(err);
     });
   }

--- a/index.js
+++ b/index.js
@@ -78,13 +78,12 @@ class ChromeRender {
       const resolveHTML = async () => {
         if (hasReturn === false) {
           try {
+            hasReturn = true;
             const dom = await DOM.getDocument();
             const ret = await DOM.getOuterHTML({ nodeId: dom.root.nodeId });
             resolve(ret.outerHTML);
           } catch (err) {
             reject(err);
-          } finally {
-            hasReturn = true;
           }
         }
         clearTimeout(timer);

--- a/index.js
+++ b/index.js
@@ -161,11 +161,11 @@ Object.defineProperty(window, 'isPageReady', {
         url,
         referrer: headers['referrer']
       });
-    }).then((html) => {
-      this.chromePoll.release(client.tabId);
+    }).then(async (html) => {
+      await this.chromePoll.release(client.tabId);
       return Promise.resolve(html);
-    }).catch((err) => {
-      this.chromePoll.release(client.tabId);
+    }).catch(async (err) => {
+      await this.chromePoll.release(client.tabId);
       return Promise.reject(err);
     });
   }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha test"
   },
   "dependencies": {
-    "chrome-pool": "^1.1.0"
+    "chrome-pool": "^1.1.2"
   },
   "devDependencies": {
     "koa": "^2.2.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -84,14 +84,19 @@ describe('#ChromeRender', function () {
       maxTab: 8
     });
     await chromeRender.render({
-      url: 'https://gwuhaolin.github.io/redemo/',
+      url: 'https://gwuhaolin.github.io/redemo/?a=1',
       useReady: true,
       script: `setTimeout(function(){window.isPageReady = 1;}, 1000);`,
       renderTimeout: 5000
     });
-
     await chromeRender.render({
-      url: 'https://gwuhaolin.github.io/redemo/',
+      url: 'https://gwuhaolin.github.io/redemo/?a=2',
+      useReady: true,
+      script: `setTimeout(function(){window.isPageReady = 1;}, 1000);`,
+      renderTimeout: 5000
+    });
+    await chromeRender.render({
+      url: 'https://gwuhaolin.github.io/redemo/?a=3',
       useReady: true,
       script: `setTimeout(function(){window.isPageReady = 1;}, 1000);`,
       renderTimeout: 5000

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,6 +79,26 @@ describe('#ChromeRender', function () {
     await chromeRender.destroyRender();
   });
 
+  it('#render() proper release', async function () {
+    const chromeRender = await ChromeRender.new({
+      maxTab: 8
+    });
+    await chromeRender.render({
+      url: 'https://gwuhaolin.github.io/redemo/',
+      useReady: true,
+      script: `setTimeout(function(){window.isPageReady = 1;}, 1000);`,
+      renderTimeout: 5000
+    });
+
+    await chromeRender.render({
+      url: 'https://gwuhaolin.github.io/redemo/',
+      useReady: true,
+      script: `setTimeout(function(){window.isPageReady = 1;}, 1000);`,
+      renderTimeout: 5000
+    });
+    await chromeRender.destroyRender();
+  });
+
   it('#render() inject script', async function () {
     const chromeRender = await ChromeRender.new();
     const html = await chromeRender.render({


### PR DESCRIPTION
Related to https://github.com/gwuhaolin/chrome-pool/pull/10

PR adds option to render method that allows to control chrome-pool behavior regarding navigating to `about:blank` after releasing chrome instance.

@gwuhaolin you may change the variable name :).