### PR TITLE
Fix unhandled rejections in rare cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,8 @@ new Promise((fulfill) => {
     once: true
   });
 })`
-            }).then(resolveHTML);
+            }).then(resolveHTML)
+              .catch(reject);
           }
         });
       } else {


### PR DESCRIPTION
In some rare cases when page crashes or something bad happens, useReady promise will be collected. And this collection should be unhanded properly.

So in order to fix this I've added `catch` that will reject parent promise that's returned from `render` function. I haven't added any tests because it's hard to reproduce this error, because it happens randomly.